### PR TITLE
Mavlink message rate check feature

### DIFF
--- a/include/task_manager/drone_state_manager.h
+++ b/include/task_manager/drone_state_manager.h
@@ -134,6 +134,7 @@ class DroneStateManager {
         int imu_count_;
         int local_pos_count_;
         int global_pos_count_;
+        float stream_rate_modifier_;
 
 };
 

--- a/launch/task_manager.launch
+++ b/launch/task_manager.launch
@@ -14,6 +14,8 @@
 
      <!-- Record -->
     <arg name="do_record" default="true"/>
+
+    <arg name="simulate" default="false"/>
     
     <node pkg="task_manager_88" type="task_manager" name="task_manager" output="screen">
         <param name="goal_topic" value="$(arg goal_topic)"/>
@@ -30,5 +32,7 @@
         <param name="imu_rate" value="50"/>
         <param name="local_pos_rate" value="30"/>
         <param name="global_pos_rate" value="5"/>
+
+        <param name="simulate" value="$(arg simulate)"/>
     </node>
 </launch>


### PR DESCRIPTION
Adds functionality to request stream rates for critical mavlink streams. Also verifies the stream rates and re-requests streams that are too slow. 

Testing steps can be found in [r88_ws PR](https://github.com/robotics88official/r88_ws/pull/2). 