### PR TITLE
Bugfix/crash when burn unit message complete

### DIFF
--- a/include/task_manager/hello_decco_manager.h
+++ b/include/task_manager/hello_decco_manager.h
@@ -77,15 +77,16 @@ class HelloDeccoManager {
         std::vector<geometry_msgs::Polygon> subpolygons_; // Flight units
         double flightleg_area_m2_;
 
-        void polygonInitializer(const geometry_msgs::Polygon &msg);
+        void polygonInitializer(const geometry_msgs::Polygon &msg, bool make_legs);
         geometry_msgs::Polygon polygonFromJson(json jsonPolygon);
 
         // Polygon mgmt
-        bool polygonToMap(const geometry_msgs::Polygon &polygon);
+        geometry_msgs::Polygon polygonToMap(const geometry_msgs::Polygon &polygon);
         bool polygonToGeofence(const geometry_msgs::Polygon &polygon);
         int polygonNumFlights(const geometry_msgs::Polygon &polygon);
         int concaveToMinimalConvexPolygons();
         void visualizeLegs();
+        void visualizePolygon();
         geometry_msgs::Polygon transformPolygon(const geometry_msgs::Polygon &map_poly);
 };
 

--- a/src/hello_decco_manager.cpp
+++ b/src/hello_decco_manager.cpp
@@ -45,19 +45,32 @@ void HelloDeccoManager::makeBurnUnitJson(json msgJson, int utm_zone) {
     // TODO check trip type to decide what data is recording? Or do that on the HD side?
     // Parse data
     burn_unit_json_ = msgJson;
+    std::cout << "burn json received as: \n" << burn_unit_json_.dump(4) << std::endl;
     std_msgs::String burn_string;
+    geometry_msgs::Polygon poly = polygonFromJson(burn_unit_json_["polygon"]);
     // Check if already filled in
     int num_flights = burn_unit_json_["trips"][0]["flights"].size();
-    if (num_flights > 1 || (num_flights == 1 && burn_unit_json_["trips"][0]["flights"][0]["subpolygon"].size() > 3)) {
+    if (num_flights >= 1 && burn_unit_json_["trips"][0]["flights"][0]["subpolygon"].size() >= 3) {
         // Already filled in, pass directly to TM
-        std::cout << "burn json was: \n" << burn_unit_json_.dump(4) << std::endl;
         std::string s = burn_unit_json_.dump();
         burn_string.data = s;
+        polygonInitializer(poly, false);
+        // Fill in subpolygon array
+        subpolygons_.clear();
+        geometry_msgs::Polygon ll_poly;
+        for (auto subpoly_point: burn_unit_json_["trips"][0]["flights"][0]["subpolygon"]) {
+            geometry_msgs::Point32 ll_point;
+            ll_point.x = subpoly_point[0];
+            ll_point.y = subpoly_point[1];
+            ll_poly.points.push_back(ll_point);
+        }
+        geometry_msgs::Polygon poly = polygonToMap(ll_poly);
+        subpolygons_.push_back(poly);
+        std::cout << "burn json was: \n" << burn_unit_json_.dump(4) << std::endl;
     }
     else {
         // Need to fill in
-        geometry_msgs::Polygon poly = polygonFromJson(burn_unit_json_["polygon"]);
-        polygonInitializer(poly); // TODO use index to decide which flight leg to send to explore
+        polygonInitializer(poly, true);
         json flightLegArray;
         for (int ii = 0; ii < subpolygons_.size(); ii++) {
             json flight_leg;
@@ -89,19 +102,19 @@ void HelloDeccoManager::makeBurnUnitJson(json msgJson, int utm_zone) {
     }
 }
 
-void HelloDeccoManager::polygonInitializer(const geometry_msgs::Polygon &msg) {
-    // Convert polygon to map coordinates and store
-    if (!polygonToMap(msg)) {
-        ROS_WARN("Failed to convert polygon to map, polygon ignored.");
-        return;
-    }
+void HelloDeccoManager::polygonInitializer(const geometry_msgs::Polygon &msg, bool make_legs) {
+    // Convert polygon to map coordinates and visualize
+    map_region_ = polygonToMap(msg);
+    visualizePolygon();
 
     if (!polygonToGeofence(msg)) {
         ROS_WARN("Failed to convert polygon to geofence");
     }
 
-    int num_legs = polygonNumFlights(msg);
-    ROS_INFO("Polygon for exploration will take %d flights to complete.", num_legs);
+    if (make_legs) {
+        int num_legs = polygonNumFlights(msg);
+        ROS_INFO("Polygon for exploration will take %d flights to complete.", num_legs);
+    }
 }
 
 int HelloDeccoManager::initBurnUnit(geometry_msgs::Polygon &polygon) {
@@ -156,8 +169,7 @@ geometry_msgs::Polygon HelloDeccoManager::polygonFromJson(json jsonPolygon) {
     return polygon;
 }
 
-
-bool HelloDeccoManager::polygonToMap(const geometry_msgs::Polygon &polygon) {
+void HelloDeccoManager::visualizePolygon() {
     visualization_msgs::Marker m;
     m.scale.x = 2.0;
     m.header.frame_id = mavros_map_frame_;
@@ -170,29 +182,32 @@ bool HelloDeccoManager::polygonToMap(const geometry_msgs::Polygon &polygon) {
     m.color.b = 0.0;
     m.id = 0;
 
-    for (int ii = 0; ii < polygon.points.size(); ii++) {
-        GeographicLib::GeoCoords coord(polygon.points.at(ii).x, polygon.points.at(ii).y);
-        geometry_msgs::Point32 poly_point;
-        poly_point.x = coord.Easting() + utm_x_offset_;
-        poly_point.y = coord.Northing() + utm_y_offset_;
-        map_region_.points.push_back(poly_point);
-
+    for (int ii = 0; ii < map_region_.points.size(); ii++) {
         // Add marker
         geometry_msgs::Point p;
-        p.x = coord.Easting() + utm_x_offset_;
-        p.y = coord.Northing() + utm_y_offset_;
+        p.x = map_region_.points.at(ii).x;
+        p.y = map_region_.points.at(ii).y;
         m.points.push_back(p);
-
-        ROS_INFO("map point was (%f, %f)", poly_point.x, poly_point.y);
-
-        // Add cvx polygon point
-        vertices_.push_back(cxd::Vec2({p.x, p.y}));
     }
     // Repost first marker at end to close the loop
     geometry_msgs::Point p = m.points.at(0);
     m.points.push_back(p);
     map_region_pub_.publish(m);
-    return true;
+}
+
+geometry_msgs::Polygon HelloDeccoManager::polygonToMap(const geometry_msgs::Polygon &polygon) {
+    // Converts lat/lon polygon to local map polygon
+    geometry_msgs::Polygon map_polygon;
+    for (int ii = 0; ii < polygon.points.size(); ii++) {
+        GeographicLib::GeoCoords coord(polygon.points.at(ii).x, polygon.points.at(ii).y);
+        geometry_msgs::Point32 poly_point;
+        poly_point.x = coord.Easting() + utm_x_offset_;
+        poly_point.y = coord.Northing() + utm_y_offset_;
+        map_polygon.points.push_back(poly_point);
+
+        ROS_INFO("map point was (%f, %f)", poly_point.x, poly_point.y);
+    }
+    return map_polygon;
 }
 
 bool HelloDeccoManager::polygonToGeofence(const geometry_msgs::Polygon &polygon) {

--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -953,7 +953,9 @@ void TaskManager::makeBurnUnitJson(const std_msgs::String::ConstPtr &msg) {
         std::string burn_status_string = "No burn units subpolygons were incomplete, not exploring. \n";
         cmd_history_.append(burn_status_string);
     }
-    getReadyForExplore();
+    else {
+        getReadyForExplore();
+    }
 }
 
 void TaskManager::makeBurnUnitJson(json burn_unit) {
@@ -974,7 +976,9 @@ void TaskManager::makeBurnUnitJson(json burn_unit) {
         std::string burn_status_string = "No burn units subpolygons were incomplete, not exploring. \n";
         cmd_history_.append(burn_status_string);
     }
-    getReadyForExplore();
+    else {
+        getReadyForExplore();
+    }
 }
 
 // Below are purely test methods, to eventually be deprecated in favor of burn units


### PR DESCRIPTION
Fixes two issues. Task manager was crashing when a burn unit was filled in (flight legs already generated) because there were missing steps needed to extract the subpolygons and map region from json. It was still crashing after that fix because Hello Decco sent burn units fully COMPLETED, resulting an index out of bounds. Now it will reject such a burn unit without crashing.

**Test:**
Launch decco.launch in AirSim with mapversation. In Hello Decco, send the burn unit called "as". Confirm in terminal that the burn unit was received and marked COMPLETED, but the ros nodes rejected it without crashing and show the printed warning:
![terminal](https://github.com/robotics-88/task-manager/assets/112721833/76a7a405-92e7-43b6-abcf-d146c0237520)

Next confirm we haven't broken anything. In Hello Decco, create a new burn unit (you can delete "as" to get it out of the way). Send this and confirm the drone takes off and starts exploring.