### PR TITLE
Burn log directory prefix fix

### DIFF
--- a/include/task_manager/task_manager.h
+++ b/include/task_manager/task_manager.h
@@ -307,6 +307,7 @@ class TaskManager {
         ros::Subscriber burn_unit_sub_;
         int current_index_;
         std::string burn_dir_prefix_;
+        std::string burn_dir_;
 
         // Task methods
         void updateCurrentTask(Task task);

--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -820,9 +820,9 @@ void TaskManager::startBag() {
     if (bag_active_) {
         return;
     }
-    logEvent(EventType::INFO, Severity::LOW, "Bag starting, prefix: " + burn_dir_prefix_);
+    logEvent(EventType::INFO, Severity::LOW, "Bag starting, dir: " + burn_dir_);
     bag_recorder::Rosbag start_bag_msg;
-    start_bag_msg.data_dir = burn_dir_prefix_;
+    start_bag_msg.data_dir = burn_dir_;
     start_bag_msg.bag_name = "decco";
     start_bag_msg.config = record_config_name_;
     start_bag_msg.header.stamp = ros::Time::now();
@@ -1131,7 +1131,7 @@ void TaskManager::makeBurnUnitJson(json burn_unit) {
         return;
     }
     std::string name = burn_unit["name"];
-    burn_dir_prefix_ = burn_dir_prefix_ + name + "/";
+    burn_dir_ = burn_dir_prefix_ + name + "/";
 
     hello_decco_manager_.setDroneLocationLocal(slam_pose_);
     bool geofence_ok;


### PR DESCRIPTION
## Description

Fixing an issue where burn directory string would keep appending the burn unit name to itself when a new burn unit was sent. So if you sent multiple burn units, you could end up with /<path>/burn_unit_name/burn_unit_name/different_burn_unit_name, etc. 

## Testing

I'll test today during my test flights, but should be simple enough to approve based on looking at code. 