### PR TITLE
Have startbag occur before arming

### DIFF
--- a/src/task_manager.cpp
+++ b/src/task_manager.cpp
@@ -566,10 +566,11 @@ void TaskManager::startTakeoff() {
         return;
     }
 
+    if (do_record_) {
+        startBag();
+    }
+
     if (flight_controller_interface_->takeOff(target_altitude_)) {
-        if (do_record_) {
-            startBag();
-        }
         in_autonomous_flight_ = true;
         updateCurrentTask(Task::TAKING_OFF);
         needs_takeoff_ = false;
@@ -579,7 +580,6 @@ void TaskManager::startTakeoff() {
         logEvent(EventType::FLIGHT_CONTROL, Severity::MEDIUM, "Takeoff request failed. Retrying.");
         takeoff_attempts_++;
     }
-
 }
 
 void TaskManager::startTransit() {


### PR DESCRIPTION
## Description
Have bag start before sending takeoff command to ensure that data gets collected before drone is in the air

## Testing

Run a sim with
ros2 launch src/vehicle-launch/launch/decco.launch simulate:=true do_record:=true

And verify the bag starts before arming. Check the bag to see that it isn't missing data