### PR TITLE
Set armed flag to true if arm callback is successful

### DIFF
--- a/src/flight_controller_interface.cpp
+++ b/src/flight_controller_interface.cpp
@@ -209,6 +209,9 @@ void FlightControllerInterface::initializeArducopter() {
         rclcpp::sleep_for(1s);
     }
 
+    // If param fetch is done, MAVLink streams should be clear, so request streams again
+    requestMavlinkStreams();
+
     // Clear geofence
     auto geofence_clear_client = service_call_node->create_client<mavros_msgs::srv::WaypointClear>("/mavros/geofence/clear");
     auto geofence_clear_req = std::make_shared<mavros_msgs::srv::WaypointClear::Request>();
@@ -837,14 +840,14 @@ bool FlightControllerInterface::arm() {
             rclcpp::FutureReturnCode::SUCCESS
             && result.get()->success){
         RCLCPP_INFO(this->get_logger(), "Vehicle armed");
-        return true;
+        armed_ = true;
     }
     else {
         RCLCPP_WARN(this->get_logger(), "Arming failed");
-        return false;
+        armed_ = false;
     }
 
-    return true;
+    return armed_;
 }
 
 bool FlightControllerInterface::takeOff(const double takeoff_altitude) {


### PR DESCRIPTION
## Description

This prevents a race condition during takeoff where we haven't gotten the next arm status callback after arming, so "armed_" is reporting false even if the vehicle is actually armed. Also re-requests mavlink rates after param fetch is done for extra certainty. 

## Testing

To be tested on Decco in the field. 